### PR TITLE
Fix: stop unnecessary extension reinstalls

### DIFF
--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -17,9 +17,9 @@ export class AgoricTerminal {
 	private consoleCloseSubscription: vscode.Disposable | undefined
 	private consoleChangeSubscription: vscode.Disposable | undefined
 
-	private sdkDirName = 'agoric-sdk'
-	private sdkRepo = 'https://github.com/Agoric/agoric-sdk'
-	private sdkRepoBranch = 'community-dev'
+	private sdkDirName = utils.sdkDirName
+	private sdkRepo = utils.sdkRepo
+	private sdkRepoBranch = utils.sdkRepoBranch
 
 	constructor(private title: string, private loggingService: ILogger) {
 		this.onExited = this.onExitedEmitter.event


### PR DESCRIPTION
Resolves #8 
-
### The Issue
The reason for the behaviour in that issue is, when the code editor is reopened, the extension checks if there are any version updates to the SDK and then if `autoUpdate` is configured to be true, it reinstalls the Agoric SDK, removing the previous Agoric SDK.

How it checks for updates is where the problem lies; the last code change made to this extension was that it should no longer clone the Agoric SDK from the `master` branch but from the `community-dev` branch; the extension checks for updates by viewing the version available in the npm registry (`npm view agoric version`) and if that version doesn't tally with the version currently installed, it auto updates (clears then reinstall) the current Agoric SDK from the git repo (`community-dev` branch).

But the agoric sdk package in the npm registry isn't built from the `community-dev` branch but the `master` branch, so it was cloning the `community-dev` branch (which was still at v0.16.0) and checking for version updates from the npm registry (and these version updates were being shipped from the `master` branch currently at v0.18.1) when the code editor was re-opened, this was leading constant & unnecessary reinstalls as complained about in the linked issue.

### The Solution
This fix now checks for version updates by using commit hashes; we take the last local commit hash of the agoric sdk (which is on the `community-dev` branch) and do a git fetch from the [remote repo](https://github.com/Agoric/agoric-sdk) `community-dev` branch and take the last commit hash from this fetch. If the last local commit hash is the same as the last remote (fetched) commit hash, we avoid re installs, else if they are different, that means there's updates and we then reinstall and resetup.